### PR TITLE
Empty lists in xml.

### DIFF
--- a/src/main/java/com/stanfy/gsonxml/XmlReader.java
+++ b/src/main/java/com/stanfy/gsonxml/XmlReader.java
@@ -269,6 +269,9 @@ public class XmlReader extends JsonReader {
       } else {
         // we have an empty list
         pushToQueue(JsonToken.END_ARRAY);
+        if (valuesQueueStart != null) {
+          nextValue();
+        }
       }
       break;
 

--- a/src/test/java/com/stanfy/gsonxml/issues/IssueEmptyList.java
+++ b/src/test/java/com/stanfy/gsonxml/issues/IssueEmptyList.java
@@ -1,0 +1,56 @@
+package com.stanfy.gsonxml.issues;
+
+import com.stanfy.gsonxml.GsonXml;
+import com.stanfy.gsonxml.GsonXmlBuilder;
+import com.stanfy.gsonxml.XmlParserCreator;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserFactory;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Issue EmptyList.
+ */
+public class IssueEmptyList {
+
+  private GsonXml gsonXml;
+
+  static class A {
+    List<I> B;
+    List<I> C;
+  }
+
+  static class I {
+    BigDecimal v;
+  }
+
+  @Before
+  public void init() {
+    XmlParserCreator parserCreator = new XmlParserCreator() {
+      public XmlPullParser createParser() {
+        try {
+          return XmlPullParserFactory.newInstance().newPullParser();
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+
+    gsonXml = new GsonXmlBuilder()
+        .setXmlParserCreator(parserCreator)
+        .create();
+  }
+
+  @Test
+  public void reproduce() {
+    A a = gsonXml.fromXml("<A><B></B><C></C></A>", A.class);
+    assertEquals("{\"B\":[],\"C\":[]}", gsonXml.getGson().toJson(a));
+  }
+
+}


### PR DESCRIPTION
If root element has two empty lists, parser doesn't recognize second list. Just returns first list.

For example,
<A><B></B><C></C></A>

Expected :{"B":[],"C":[]}
Actual  :{"B":[]}